### PR TITLE
Stacks para scripts

### DIFF
--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -138,7 +138,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="{{ asset('js/panel.js') }}"></script>
-    <script src="{{ asset('js/module_user.js') }}"></script>
     
     @stack('scripts')
     

--- a/resources/views/modulos/usuario.blade.php
+++ b/resources/views/modulos/usuario.blade.php
@@ -495,3 +495,7 @@
         </div>
     </div>
 @endsection
+
+@push('scripts')
+    <script src="{{ asset('js/module_user.js') }}"></script>
+@endpush


### PR DESCRIPTION
Se divide los scripts por medio de stacks, esto con el objetivo que al cargar cualquier módulo sólo cargue el js correspondiente con sus funciones.